### PR TITLE
Add some documentation, fix runtime error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # libsstv
 SSTV C encoder/decoder library for embedded systems.
+
+## Usage:
+```
+./sstv-encode
+    -input (input image) type: string default: ""
+    -mode (SSTV mode for encoder) type: string default: ""
+    -output (output WAV file) type: string default: ""
+    -sample_rate (output audio sample rate) type: uint64 default: 48000
+```
+
+## Install
+
+install dependencies (tested on devuan 4 chimaera - debian 11 bullseye based and debian 11 on raspberry pi):
+```
+sudo apt update
+sudo apt install libgoogle-glog-dev libgflags-dev libmagick++-dev libsndfile1-dev make cmake
+```
+go to the `bin` folder, run cmake and then compile with make:
+```
+cd bin
+cmake ..
+make
+```
+now you can run `./sstv-encode`

--- a/src/tools/sstv-encode.cpp
+++ b/src/tools/sstv-encode.cpp
@@ -18,7 +18,7 @@
 /*
  * Command line flags
  */
-DEFINE_bool(logtostderr, false, "Only log to stderr");
+//DEFINE_bool(logtostderr, false, "Only log to stderr");
 DEFINE_string(mode, "", "SSTV mode for encoder");
 DEFINE_string(input, "", "input image");
 DEFINE_string(output, "", "output WAV file");


### PR DESCRIPTION
When compiled on devuan 4 chimaera i got a runtime error about `logtostderr` flag being set twice: `ERROR: flag 'logtostderr' was defined more than once (in files './src/logging.cc' and '/home/user/libsstv/src/tools/sstv-encode.cpp')`. Also i figured out the compilation process and described it in README